### PR TITLE
feat: Add OCM Dimensions Three.js and p5.js library support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 lib
 .env
 build
-regtest.json
+regtest.jsonenv/

--- a/README.MD
+++ b/README.MD
@@ -56,6 +56,67 @@ Run the following command to create the html file and inscribe it to regtest. Th
 bun run generate
 ```
 
+## OCM Libraries (Three.js & p5.js)
+
+OPM includes built-in support for [OCM Dimensions](https://github.com/metagood/OCM-Dimensions) on-chain libraries. These are production-proven libraries inscribed on Bitcoin that enable rich 3D and generative art via recursive inscriptions.
+
+### Available OCM Packages
+
+| Package | Library | Inscription |
+|---------|---------|-------------|
+| `OCMDimensions` | fflate + Three.js bundle | `2dbdf9ebb...i0` |
+| `p5js` | p5.js creative coding | `255ce0c5a...i0` |
+
+### How OCM Libraries Differ
+
+Standard packages (like Matter.js) are plain JS files loaded via `<script src="/content/{{id}}">`. OCM libraries use a different pattern:
+
+- **OCM Dimensions** is an HTML inscription containing compressed fflate (line 28) and Three.js (line 32) as embedded scripts
+- Libraries are loaded by fetching the inscription, splitting by lines, and extracting the code
+- This recursive approach is extremely space-efficient on Bitcoin
+
+### Quick Start: Three.js
+
+```bash
+# 1. Download and inscribe all packages to regtest
+bun run opm
+
+# 2. Build and inscribe a Three.js artwork
+bun run generate:threejs
+
+# 3. View it
+sh server.sh
+```
+
+Edit your artwork in `templates/threejs/template.html` — put your Three.js code inside the `userCode()` function.
+
+### Quick Start: p5.js
+
+```bash
+bun run opm
+bun run generate:p5js
+sh server.sh
+```
+
+Edit your sketch in `templates/p5js/template.html` — put your p5.js code inside the `userCode()` function.
+
+### Creating Custom OCM Templates
+
+You can create your own templates that use the OCM loader pattern. The key is fetching the OCM Dimensions inscription and extracting libraries by line number:
+
+```javascript
+// Fetch OCM Dimensions bundle
+const resp = await fetch("/content/{{OCMDimensions}}");
+const html = await resp.text();
+const lines = html.split("\n");
+
+// Extract libraries
+const fflateCode = lines[28];  // fflate compression library
+const threeCode = lines[32];   // Three.js 3D library
+```
+
+For more details on the OCM workflow, compression, and advanced techniques, see the [OCM Dimensions repository](https://github.com/metagood/OCM-Dimensions).
+
 ## Viewing the html file
 
 run the ord server in regtest mode with:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   },
   "scripts": {
     "generate": "bun ./templates/template.ts",
+    "generate:threejs": "bun ./templates/threejs/template.ts",
+    "generate:p5js": "bun ./templates/p5js/template.ts",
     "balance": "ord -r wallet balance",
     "inscribe": "bun ./utils/inscribe.ts",
     "opm": "bun ./utils/opm.ts"

--- a/package.opm.json
+++ b/package.opm.json
@@ -1,4 +1,6 @@
 {
   "MatterJS": "9d567e6ef8bd6b13458cc67cc5e8339395a4433e45db4554ff83c88a5df8bae2i0",
-  "jQuery": "773e4865bcf3084e6d6ee5d49136fb5f7071d4c050ec4aeeaeb9c6d24fea5fc1i0"
+  "jQuery": "773e4865bcf3084e6d6ee5d49136fb5f7071d4c050ec4aeeaeb9c6d24fea5fc1i0",
+  "OCMDimensions": "2dbdf9ebbec6be793fd16ae9b797c7cf968ab2427166aaf390b90b71778266abi0",
+  "p5js": "255ce0c5a0d8aca39510da72e604ef8837519028827ba7b7f723b7489f3ec3a4i0"
 }

--- a/templates/p5js/template.html
+++ b/templates/p5js/template.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        margin: 0;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      // OCM loader — fetches fflate from OCM Dimensions + p5.js from its own inscription
+      (async function () {
+        try {
+          // Fetch OCM Dimensions inscription for fflate
+          const resp = await fetch("/content/{{OCMDimensions}}");
+          if (!resp.ok) throw new Error("Fetch failed: " + resp.status);
+          const html = await resp.text();
+          const lines = html.split("\n");
+          const fflateCode = lines[28];
+
+          // Fetch p5.js library inscription
+          const p5resp = await fetch("/content/{{p5js}}");
+          if (!p5resp.ok) throw new Error("p5.js fetch failed: " + p5resp.status);
+          const p5Code = await p5resp.text();
+
+          // Load fflate + p5.js
+          const s = document.createElement("script");
+          s.innerHTML = fflateCode + ';\nconst d3="' + p5Code + '"';
+          document.body.appendChild(s);
+
+          // Load p5 from the string
+          const p5Script = document.createElement("script");
+          p5Script.innerHTML = p5Code;
+          document.body.appendChild(p5Script);
+
+          // User code runs after libraries are loaded
+          userCode();
+        } catch (e) {
+          console.error("Failed to load OCM libraries:", e);
+        }
+      })();
+
+      function userCode() {
+        // ── YOUR P5.JS CODE BELOW ──
+
+        new p5(function (p) {
+          p.setup = function () {
+            p.createCanvas(p.windowWidth, p.windowHeight);
+            p.background(0);
+          };
+
+          p.draw = function () {
+            p.fill(p.random(255), p.random(255), p.random(255), 50);
+            p.noStroke();
+            p.ellipse(p.mouseX, p.mouseY, 50, 50);
+          };
+
+          p.windowResized = function () {
+            p.resizeCanvas(p.windowWidth, p.windowHeight);
+          };
+        });
+
+        // ── YOUR P5.JS CODE ABOVE ──
+      }
+    </script>
+  </body>
+</html>

--- a/templates/p5js/template.html
+++ b/templates/p5js/template.html
@@ -11,15 +11,16 @@
   </head>
   <body>
     <script>
-      // OCM loader — fetches fflate from OCM Dimensions + p5.js from its own inscription
+      // OCM p5.js loader — fetches p5.js from its on-chain inscription
+      // fflate is available from OCM Dimensions if you need compression later
       (async function () {
         try {
-          // Fetch OCM Dimensions inscription for fflate
-          const resp = await fetch("/content/{{OCMDimensions}}");
-          if (!resp.ok) throw new Error("Fetch failed: " + resp.status);
-          const html = await resp.text();
-          const lines = html.split("\n");
-          const fflateCode = lines[28];
+          // Fetch OCM Dimensions inscription (for fflate, available if needed)
+          const dimResp = await fetch("/content/{{OCMDimensions}}");
+          if (!dimResp.ok) throw new Error("OCM Dimensions fetch failed: " + dimResp.status);
+          const dimHtml = await dimResp.text();
+          const dimLines = dimHtml.split("\n");
+          const fflateCode = dimLines[28];
 
           // Fetch p5.js library inscription
           const p5resp = await fetch("/content/{{p5js}}");
@@ -28,13 +29,8 @@
 
           // Load fflate + p5.js
           const s = document.createElement("script");
-          s.innerHTML = fflateCode + ';\nconst d3="' + p5Code + '"';
+          s.innerHTML = fflateCode + ";\n" + p5Code;
           document.body.appendChild(s);
-
-          // Load p5 from the string
-          const p5Script = document.createElement("script");
-          p5Script.innerHTML = p5Code;
-          document.body.appendChild(p5Script);
 
           // User code runs after libraries are loaded
           userCode();

--- a/templates/p5js/template.ts
+++ b/templates/p5js/template.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import Handlebars from "handlebars";
+import { execSync } from "child_process";
+import path from "path";
+import { isOrdVersionGreaterOrEqual } from "../../utils/checkordversion";
+
+const isOrdV_GTE_0_10_0 = isOrdVersionGreaterOrEqual("0.10.0");
+const dir = path.join(import.meta.dir, "../../build");
+
+// Read template file
+const templateFile = fs.readFileSync(
+  path.join(import.meta.dir, "template.html"),
+  "utf8"
+);
+const template = Handlebars.compile(templateFile);
+
+// Read regtest inscription IDs
+const libraries = JSON.parse(
+  fs.readFileSync(path.join(import.meta.dir, "../../regtest.json"), "utf8")
+);
+
+// Generate the HTML with OCM Dimensions + p5.js inscription IDs
+const html = template({
+  OCMDimensions: libraries.OCMDimensions,
+  p5js: libraries.p5js,
+});
+
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir);
+}
+
+fs.writeFileSync(path.join(dir, "inscription.html"), html);
+console.log("p5.js inscription built → build/inscription.html");
+
+async function inscribe() {
+  const command = `ord -r wallet inscribe ${isOrdV_GTE_0_10_0 ? "--file" : ""} ${dir}/inscription.html --fee-rate 1 --no-backup`;
+  await execSync(command);
+
+  let receiveAddress: string | Buffer = execSync("ord -r wallet receive");
+  receiveAddress = receiveAddress.toString().trim();
+  receiveAddress = JSON.parse(receiveAddress).address;
+
+  await execSync(
+    `bitcoin-cli -regtest generatetoaddress 1 ${receiveAddress}`
+  );
+
+  console.log("p5.js inscription mined!");
+}
+
+inscribe();

--- a/templates/p5js/template.ts
+++ b/templates/p5js/template.ts
@@ -38,7 +38,8 @@ async function inscribe() {
 
   let receiveAddress: string | Buffer = execSync("ord -r wallet receive");
   receiveAddress = receiveAddress.toString().trim();
-  receiveAddress = JSON.parse(receiveAddress).address;
+  const parsed = JSON.parse(receiveAddress);
+  receiveAddress = parsed.addresses ? parsed.addresses[0] : parsed.address;
 
   await execSync(
     `bitcoin-cli -regtest generatetoaddress 1 ${receiveAddress}`

--- a/templates/template.ts
+++ b/templates/template.ts
@@ -39,7 +39,8 @@ async function inscribe() {
   // mine the inscription
   let receiveAddress: string | Buffer = execSync('ord -r wallet receive');
   receiveAddress = receiveAddress.toString().trim();
-  receiveAddress = JSON.parse(receiveAddress).address;
+  const parsed = JSON.parse(receiveAddress);
+  receiveAddress = parsed.addresses ? parsed.addresses[0] : parsed.address;
 
   await execSync(`bitcoin-cli -regtest generatetoaddress 1 ${receiveAddress}`);
 

--- a/templates/threejs/template.html
+++ b/templates/threejs/template.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        margin: 0;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="scene"></div>
+    <script>
+      // OCM Dimensions loader — fetches fflate + Three.js from the on-chain bundle
+      (async function () {
+        try {
+          // Fetch the OCM Dimensions inscription (contains fflate + Three.js)
+          const resp = await fetch("/content/{{OCMDimensions}}");
+          if (!resp.ok) throw new Error("Fetch failed: " + resp.status);
+          const html = await resp.text();
+          const lines = html.split("\n");
+
+          // Extract fflate (line 28) and Three.js (line 32) from the bundle
+          const fflateCode = lines[28];
+          const threeCode = lines[32];
+
+          // Load fflate + Three.js
+          const s = document.createElement("script");
+          s.innerHTML = fflateCode + ";\n" + threeCode;
+          document.body.appendChild(s);
+
+          // User code runs after libraries are loaded
+          userCode();
+        } catch (e) {
+          console.error("Failed to load OCM libraries:", e);
+        }
+      })();
+
+      function userCode() {
+        // ── YOUR THREE.JS CODE BELOW ──
+
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera(
+          75,
+          innerWidth / innerHeight,
+          0.1,
+          1000
+        );
+        camera.position.z = 5;
+
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setSize(innerWidth, innerHeight);
+        document.getElementById("scene").appendChild(renderer.domElement);
+
+        const geometry = new THREE.BoxGeometry();
+        const material = new THREE.MeshNormalMaterial();
+        const cube = new THREE.Mesh(geometry, material);
+        scene.add(cube);
+
+        function animate() {
+          requestAnimationFrame(animate);
+          cube.rotation.x += 0.01;
+          cube.rotation.y += 0.01;
+          renderer.render(scene, camera);
+        }
+        animate();
+
+        window.addEventListener("resize", () => {
+          camera.aspect = innerWidth / innerHeight;
+          camera.updateProjectionMatrix();
+          renderer.setSize(innerWidth, innerHeight);
+        });
+
+        // ── YOUR THREE.JS CODE ABOVE ──
+      }
+    </script>
+  </body>
+</html>

--- a/templates/threejs/template.ts
+++ b/templates/threejs/template.ts
@@ -35,7 +35,8 @@ async function inscribe() {
 
   let receiveAddress: string | Buffer = execSync("ord -r wallet receive");
   receiveAddress = receiveAddress.toString().trim();
-  receiveAddress = JSON.parse(receiveAddress).address;
+  const parsed = JSON.parse(receiveAddress);
+  receiveAddress = parsed.addresses ? parsed.addresses[0] : parsed.address;
 
   await execSync(
     `bitcoin-cli -regtest generatetoaddress 1 ${receiveAddress}`

--- a/templates/threejs/template.ts
+++ b/templates/threejs/template.ts
@@ -1,0 +1,47 @@
+import fs from "fs";
+import Handlebars from "handlebars";
+import { execSync } from "child_process";
+import path from "path";
+import { isOrdVersionGreaterOrEqual } from "../../utils/checkordversion";
+
+const isOrdV_GTE_0_10_0 = isOrdVersionGreaterOrEqual("0.10.0");
+const dir = path.join(import.meta.dir, "../../build");
+
+// Read template file
+const templateFile = fs.readFileSync(
+  path.join(import.meta.dir, "template.html"),
+  "utf8"
+);
+const template = Handlebars.compile(templateFile);
+
+// Read regtest inscription IDs
+const libraries = JSON.parse(
+  fs.readFileSync(path.join(import.meta.dir, "../../regtest.json"), "utf8")
+);
+
+// Generate the HTML with the OCM Dimensions inscription ID
+const html = template({ OCMDimensions: libraries.OCMDimensions });
+
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir);
+}
+
+fs.writeFileSync(path.join(dir, "inscription.html"), html);
+console.log("Three.js inscription built → build/inscription.html");
+
+async function inscribe() {
+  const command = `ord -r wallet inscribe ${isOrdV_GTE_0_10_0 ? "--file" : ""} ${dir}/inscription.html --fee-rate 1 --no-backup`;
+  await execSync(command);
+
+  let receiveAddress: string | Buffer = execSync("ord -r wallet receive");
+  receiveAddress = receiveAddress.toString().trim();
+  receiveAddress = JSON.parse(receiveAddress).address;
+
+  await execSync(
+    `bitcoin-cli -regtest generatetoaddress 1 ${receiveAddress}`
+  );
+
+  console.log("Three.js inscription mined!");
+}
+
+inscribe();

--- a/utils/opm.ts
+++ b/utils/opm.ts
@@ -77,7 +77,8 @@ async function run() {
 
     let receiveAddress: string | Buffer = execSync('ord -r wallet receive');
     receiveAddress = receiveAddress.toString().trim();
-    receiveAddress = JSON.parse(receiveAddress).address;
+    const parsed = JSON.parse(receiveAddress);
+    receiveAddress = parsed.addresses ? parsed.addresses[0] : parsed.address;
 
     execSync(`bitcoin-cli -regtest generatetoaddress 1 ${receiveAddress}`);
     console.log('Libraries mined!');


### PR DESCRIPTION
## Summary

Adds built-in support for [OCM Dimensions](https://github.com/metagood/OCM-Dimensions) on-chain libraries, enabling Three.js 3D graphics and p5.js creative coding workflows in OPM.

Closes #8

## What's Changed

### New packages in `package.opm.json`
- **OCMDimensions** — fflate + Three.js bundle inscription (`2dbdf9ebb...i0`)
- **p5js** — p5.js creative coding library inscription (`255ce0c5a...i0`)

### New templates
- **`templates/threejs/`** — Three.js template + build script with OCM recursive loader
- **`templates/p5js/`** — p5.js template + build script with OCM recursive loader

### New npm scripts
- `bun run generate:threejs` — Build and inscribe a Three.js artwork
- `bun run generate:p5js` — Build and inscribe a p5.js sketch

### README updates
- Full documentation section on OCM libraries
- Explains the fetch+extract pattern (OCM libs are embedded as lines within an HTML inscription, not plain JS files)
- Quick start guides for both workflows
- Guide for creating custom OCM templates

## How OCM Libraries Work

OCM Dimensions libraries are different from standard JS packages. Instead of `<script src="/content/{{id}}">`, they use a recursive fetch pattern:

1. Fetch the OCM Dimensions inscription (an HTML file)
2. Split by lines to extract fflate (line 28) and Three.js (line 32)
3. Inject as script elements

This is extremely space-efficient on Bitcoin and is the same production-proven pattern used by the OCM Dimensions collection (10K+ inscriptions).

## Testing

1. `bun run opm` — downloads and inscribes OCM packages to regtest
2. `bun run generate:threejs` or `bun run generate:p5js` — builds and inscribes
3. `sh server.sh` — view the inscription locally